### PR TITLE
Support dropping existing tables on Oracle for flexible views

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>liquibase.ext.otbo</groupId>
 	<artifactId>liquibase-otbo</artifactId>
-	<version>4.29.2.1</version>
+	<version>4.29.2.2</version>
 
 	<properties>
 		<oracle.version>23.5.0.24.07</oracle.version>

--- a/src/main/java/liquibase/ext/otbo/changes/CreateFlexibleViewGenerator.java
+++ b/src/main/java/liquibase/ext/otbo/changes/CreateFlexibleViewGenerator.java
@@ -46,21 +46,25 @@ public class CreateFlexibleViewGenerator extends OtboSqlGenerator<CreateFlexible
 	}
 
 	/**
-	 * 1. If there is a materialized view (oracle) or table (mssql only) with the same name as this view, we drop it.
-	 * 2. We can then can create the standard view: 'create or replace force view as ... select 1 from dual' 
-	 * 3. If the environment is set for materialized views, convert all views to materialized views (oracle) or tables (mssql) at the end using the v99.99.99 script.
+	 * 1. If there is a materialized view (oracle) with the same name as this view, drop it.
+	 * 2. If there is a table (oracle or mssql) with the same name as this view, drop it.
+	 * 3. We can then can create the standard view: 'create or replace force view as ... select 1 from dual' 
 	 */
 	public Sql[] generateSql( CreateFlexibleViewStatement statement, Database database, SqlGeneratorChain<CreateFlexibleViewStatement> sqlGeneratorChain ) {
 		// check if the view already exists, then formulate a plan from there!
 		String viewName = statement.getViewName().toUpperCase();
 		List<Sql> sequel = new ArrayList<Sql>();
 
-		if ( materializedViewExists( viewName, database ) ) {
+		// 1. Drop the materialized view if it exists (oracle only).
+		if ( database instanceof OracleDatabase && materializedViewExists( viewName, database ) ) {
 			DropMaterializedViewStatement dropMViewStmt = new DropMaterializedViewStatement( statement.getViewName() );
 			dropMViewStmt.setSchemaName( database.getDefaultSchemaName() );
 			DropMaterializedViewGenerator dropMViewGen = new DropMaterializedViewGenerator();
 			sequel.addAll( Arrays.asList( dropMViewGen.generateSql( dropMViewStmt, database, null ) ) );
-		} else if ( database instanceof MSSQLDatabase && tableExists( viewName, database ) ) {
+		}
+
+		// 2. Drop the table if it exists (oracle or mssql).
+		if ( tableExists( viewName, database ) ) {
 			DropTableStatement dropTableStmt = new DropTableStatement( database.getDefaultCatalogName(), database.getDefaultSchemaName(), viewName, true );
 			DropTableGenerator dropTableGen = new DropTableGenerator();
 			sequel.addAll( Arrays.asList( dropTableGen.generateSql( dropTableStmt, database, null ) ) );
@@ -68,6 +72,8 @@ public class CreateFlexibleViewGenerator extends OtboSqlGenerator<CreateFlexible
 		
 		// if the view exists as a regular view already, we don't actually care.
 		String selectQuery = addSchemaPrefixToFunctionNames( statement.getSelectQuery(), database );
+		
+		// 3. Create the standard view.
 		CreateViewStatement createViewStmt = new CreateViewStatement( database.getDefaultCatalogName(), database.getDefaultSchemaName(), statement.getViewName(), selectQuery, true );
 
 		CreateViewGenerator createViewGen = new CreateViewGenerator();


### PR DESCRIPTION
Updates the generator to check for and drop existing tables on Oracle before creating a flexible view, aligning its behavior with the existing MSSQL logic. Additionally, restricts materialized view checks to Oracle databases and increments the project version to 4.29.2.2.